### PR TITLE
Fix Validate of Image with tag containing latest

### DIFF
--- a/pkg/validator/task_validator.go
+++ b/pkg/validator/task_validator.go
@@ -93,7 +93,7 @@ func (t *taskValidator) validateStep(s v1beta1.Step) Result {
 		return result
 	}
 
-	if strings.Contains(ref.Identifier(), "latest") {
+	if strings.EqualFold(ref.Identifier(), "latest") {
 		result.Error("Step %q uses image %q which must be tagged with a specific version", step, img)
 	}
 

--- a/pkg/validator/task_validator_test.go
+++ b/pkg/validator/task_validator_test.go
@@ -64,6 +64,8 @@ spec:
     image: abc.io/xyz/fedora:latest-0.2@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
   - name: s10
     image: abc.io/xyz/fedora:latest0.2@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
+  - name: s11
+    image: quay.io/foo/bar:stable-2.12-latest
 `
 
 const taskWithInvalidImageRef = `


### PR DESCRIPTION
Catlin throws error when the image with tag `stable-2.12-latest`
comes which is still valid. Replacing the check from `Contains` to
`EqualFold` so that it throws error iff tag `latest` comes.

Signed-off-by: vinamra28 <jvinamra776@gmail.com>