### PR TITLE
[TEP-0115] Git-based Versioning Validation

### DIFF
--- a/pkg/cmd/validate/testdata/task/maven-git-versioning/maven-git-versioning.yaml
+++ b/pkg/cmd/validate/testdata/task/maven-git-versioning/maven-git-versioning.yaml
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: maven-git-versioning
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: build-automation
+    tekton.dev/categories: Build Tools
+    tekton.dev/displayName: "maven"
+spec:
+  description: >-
+    This Task can be used to run a Maven build.
+  params:
+    - name: GOALS
+      type: array
+  steps:
+    - name: execute-goals
+      image: gcr.io/cloud-builders/mvn:3.6.8@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641
+      command:
+        - mvn
+      args:
+        - $(params.GOALS)

--- a/pkg/cmd/validate/testdata/task/npm-git-versioning/npm-git-versioning.yaml
+++ b/pkg/cmd/validate/testdata/task/npm-git-versioning/npm-git-versioning.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: npm-git-versioning
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: build-automation
+    tekton.dev/categories: Build Tools
+    tekton.dev/displayName: "npm"
+spec:
+  description: >-
+    This task can be used to run npm goals on a project.
+
+    This task can be used to run npm goals on a project
+    where package.json is present and has some pre-defined
+    npm scripts.
+  params:
+    - name: GOALS
+      type: array
+  steps:
+    - name: execute-goals
+      image: docker.io/library/node:12-alpine@sha256:12048cdfd75d944df35f3144132d9bdeee78015fbd6df765edad1be46599b110
+      command:
+        - npm
+      args:
+        - $(params.GOALS)

--- a/pkg/cmd/validate/validate_test.go
+++ b/pkg/cmd/validate/validate_test.go
@@ -36,8 +36,26 @@ func TestValidate(t *testing.T) {
 			want:      "",
 		},
 		{
+			name:      "single filepath - with directory versioning flag",
+			args:      []string{"./testdata/task/maven/0.1", "--versioning", "directory"},
+			wantError: false,
+			want:      "",
+		},
+		{
+			name:      "single filepath git versioning",
+			args:      []string{"./testdata/task/maven-git-versioning", "--versioning", "git"},
+			wantError: false,
+			want:      "",
+		},
+		{
 			name:      "multiple filepath",
 			args:      []string{"./testdata/task/maven/0.1", "./testdata/task/npm/0.1"},
+			wantError: false,
+			want:      "",
+		},
+		{
+			name:      "multiple filepath git versioning",
+			args:      []string{"./testdata/task/maven-git-versioning", "./testdata/task/npm-git-versioning", "--versioning", "git"},
 			wantError: false,
 			want:      "",
 		},
@@ -71,6 +89,18 @@ func TestValidateError(t *testing.T) {
 			args:      []string{"./testdata/task/black/0.1"},
 			wantError: true,
 			want:      "Error: ./testdata/task/black/0.1/black.yaml failed validation\n",
+		},
+		{
+			name:      "versioning mismatch - git versioning",
+			args:      []string{"./testdata/task/maven/0.1", "--versioning", "git"},
+			wantError: true,
+			want:      "Error: ./testdata/task/maven/0.1/maven.yaml failed validation\n",
+		},
+		{
+			name:      "versioning mismatch - directory versioning",
+			args:      []string{"./testdata/task/maven-git-versioning", "--versioning", "directory"},
+			wantError: true,
+			want:      "Error: ./testdata/task/maven-git-versioning/maven-git-versioning.yaml failed validation\n",
 		},
 	}
 


### PR DESCRIPTION
Prior to this change, the Catlin validation only supports directory-based catalog path validation (i.e. `./<catalog>/<kind>/<name>/<version>/<name>.yaml`). The git-based versioning catalog is proposed in [TEP-0115]( https://github.com/tektoncd/community/blob/main/teps/0115-tekton-catalog-git-based-versioning.md), with a new file path layout (i.e. `./<catalog>/<kind>/<name>/<name>.yaml`).

This commit introduces a new flag `versioning` to the `catlin validate` command, indicating the versioning type of the catalog to validate. The value can be set to either `directory` or `git`. The default value is `directory`.