### PR TITLE
Update tools.go to use update build tag

### DIFF
--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 


### PR DESCRIPTION
Build CI was failing because of tools.go using older go build tag. Updating this to use the latest one in order to fix the CI

Signed-off-by: vinamra28 <jvinamra776@gmail.com>