### PR TITLE
feat: add cherry-pick command workflow and fix slash.yml

### DIFF
--- a/.github/workflows/cherry-pick-command.yaml
+++ b/.github/workflows/cherry-pick-command.yaml
@@ -1,0 +1,32 @@
+# Cherry Pick Command Workflow
+#
+# This workflow is triggered by the /cherry-pick slash command from the slash.yml workflow.
+# It automatically cherry-picks merged PRs to the specified target branches.
+#
+# Usage: Comment `/cherry-pick <target-branch> [<target-branch> ...]` on a merged pull request
+# Example: `/cherry-pick release-v1.0.x`
+# Example: `/cherry-pick release-v1.0.x release-v1.1.x`
+#
+# Security Notes:
+# - Only users with "write" permission can trigger this command (enforced in slash.yml)
+# - Works safely with PRs from forks because it only cherry-picks already-merged commits
+# - Uses CHATOPS_TOKEN to create PRs and push to branches
+# - The action creates a new branch from the target branch, not from the fork
+
+name: Cherry Pick Command
+
+on:
+  repository_dispatch:
+    types: [cherry-pick-command]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  cherry-pick:
+    name: Cherry Pick Actions
+    uses: tektoncd/plumbing/.github/workflows/_cherry-pick-command.yaml@4b57443b85569e5bb7d9ee440bf5cae99cb642cb
+    secrets:
+      CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -12,8 +12,8 @@
 # named <command>-command which must exist in the repository.
 #
 # Supported commands:
-# - /land: invokes the land-command workflow, to land (merge) PRs
-#          stacked through ghstack
+# - /retest: re-trigger workflows that failed on a given PR
+# - /cherry-pick <branch>: cherry-picks the merged PR to the specified branch
 #
 # When a command is recognised, the rocket and eyes emojis are added
 
@@ -26,8 +26,8 @@ jobs:
   check_comments:
     runs-on: ubuntu-latest
     steps:
-    - name: route-land
-      uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0
+    - name: route-slash-commands
+      uses: peter-evans/slash-command-dispatch@5c11dc7efead556e3bdabf664302212f79eb26fa # v5.0.1
       with:
         token: ${{ secrets.CHATOPS_TOKEN }}
         config: >
@@ -36,6 +36,12 @@ jobs:
               "command": "retest",
               "permission": "write",
               "issue_type": "pull-request",
-              "repository": "tektoncd/pipeline"
+              "repository": "tektoncd/catlin"
+            },
+            {
+              "command": "cherry-pick",
+              "permission": "write",
+              "issue_type": "pull-request",
+              "repository": "tektoncd/catlin"
             }
           ]


### PR DESCRIPTION
# Changes

This PR adds the cherry-pick command workflow to catlin and fixes an existing bug in slash.yml (addresses tektoncd/plumbing#3004).

**What's included:**
- New `cherry-pick-command.yaml` workflow using the centralized plumbing reusable workflow
- Updated `slash.yml` to include cherry-pick command configuration
- **Bug fix**: Corrected repository name in slash.yml from `tektoncd/pipeline` to `tektoncd/catlin`
- Updated slash-command-dispatch action from v4.0.0 to v5.0.1

**Benefits:**
- Streamlines cherry-picking to release branches with simple slash command
- Uses centralized, well-tested logic from tektoncd/plumbing
- Consistent behavior with other tektoncd repositories
- Fixes incorrect repository reference that could cause retest command issues

**Usage:**
Comment `/cherry-pick release-v1.0.x` on a merged PR to automatically create a cherry-pick PR to that branch.

# Submitter Checklist

- [x] Includes tests (N/A - workflow files only)
- [x] Includes docs (comprehensive inline documentation in workflow files)
- [x] Commit messages follow commit message best practices

# Release Notes

```release-note
NONE
```