### PR TITLE
chore: migrate retest workflow to use plumbing reusable workflow

### DIFF
--- a/.github/workflows/chatops_retest.yaml
+++ b/.github/workflows/chatops_retest.yaml
@@ -1,14 +1,8 @@
-# The _chatops_retest workflow reruns failed GHA for a PR
-#
-# This workflow is triggered by leaving a "/retest" comment on
-# a pull request. If the required preconditions are met, it will
-# rerun failed GitHub actions checks on that PR
-#
-# Condition for the "/retest" command are:
-# - either the issuer is a maintainer
-# - or the issuer is the owner the PR
-
 name: Rerun Failed Actions
+
+permissions:
+  contents: read
+
 on:
   repository_dispatch:
     types: [retest-command]
@@ -16,66 +10,5 @@ on:
 jobs:
   retest:
     name: Rerun Failed Actions
-    runs-on: ubuntu-latest
-    steps:
-    - name: Show Environment Variables
-      run: env
-    - name: Show Github Object
-      run: |
-        cat <<'EOF'
-        ${{ toJson(github) }}
-        EOF
-    - name: Show Github Event Path Json
-      run: 'cat $GITHUB_EVENT_PATH || true'
-    - name: Rerun Failed Actions
-      run: |
-        echo '::group:: Get the PR commit sha'
-        # Get the sha of the HEAD commit in the PR
-        GITHUB_COMMIT_SHA=$(gh api $(echo ${GITHUB_PULL_URL#https://api.github.com/}) | \
-            jq -r .head.sha)
-        echo GITHUB_COMMIT_SHA=${GITHUB_COMMIT_SHA}
-        echo '::endgroup::'
-
-        echo '::group:: Get the list of run IDs'
-        # Get a list of run IDs
-        RUN_IDS=$(gh api repos/${GITHUB_REPO}/commits/${GITHUB_COMMIT_SHA}/check-runs | \
-            jq -r '.check_runs[] | select(.name != "Rerun Failed Actions") | .html_url | capture("/runs/(?<number>[0-9]+)/job") | .number' | \
-            sort -u)
-        echo RUN_IDS=${RUN_IDS}
-        echo '::endgroup::'
-
-        echo '::group:: Rerun failed runs'
-        # For each run, retrigger faild jobs
-        for runid in ${RUN_IDS}; do
-            echo Restarting run ${runid} for commit ${GITHUB_COMMIT_SHA}
-            gh run \
-                --repo ${GITHUB_REPO} \
-                rerun ${runid} \
-                --failed || true
-        done
-        echo '::endgroup::'
-      env:
-        GITHUB_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
-        GITHUB_REPO: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        GITHUB_PULL_URL: ${{ github.event.client_payload.github.payload.issue.pull_request.url }}
-
-    - name: Create comment
-      if: ${{ failure() && steps.landStack.outcome == 'failure' }}
-      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-      with:
-        token: ${{ secrets.CHATOPS_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
-        body: |
-          Something went wrong with your `/${{ github.event.client_payload.slash_command.command }}` command: [please check the logs][1].
-
-          [1]: ${{ steps.vars.outputs.run-url }}
-
-    - name: Add reaction
-      if: ${{ success() }}
-      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-      with:
-        token: ${{ secrets.CHATOPS_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-        reactions: hooray
+    uses: tektoncd/plumbing/.github/workflows/_chatops_retest.yml@c9d6729a374829a3486b3b4a3c7c67d8b0926f04
+    secrets: inherit


### PR DESCRIPTION
This migrates the local chatops_retest.yaml implementation to use the centralized reusable workflow from tektoncd/plumbing, reducing duplication and ensuring consistency across repositories.

The workflow now delegates to:
`tektoncd/plumbing/.github/workflows/_chatops_retest.yml@c9d6729a374829a3486b3b4a3c7c67d8b0926f04`

This change reduces the file from 81 lines to 15 lines while maintaining the same functionality.

Related to tektoncd/plumbing#3005

/kind misc