### PR TITLE
Add support for tekton.dev/v1 Task and Pipeline types

### DIFF
--- a/pkg/cmd/validate/testdata/task/v1-hello/0.1/v1-hello.yaml
+++ b/pkg/cmd/validate/testdata/task/v1-hello/0.1/v1-hello.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: v1-hello
+  labels:
+    app.kubernetes.io/version: '0.1'
+  annotations:
+    tekton.dev/pipelines.minVersion: '0.12.1'
+    tekton.dev/tags: hello
+    tekton.dev/categories: Build Tools
+    tekton.dev/displayName: 'Hello v1'
+    tekton.dev/platforms: 'linux/amd64'
+spec:
+  description: >-
+    A minimal tekton.dev/v1 Task used to verify catlin validates v1 resources.
+  steps:
+    - name: hello
+      image: docker.io/library/ubuntu:1.0
+      command:
+        - /bin/sh
+        - -c
+        - echo hello

--- a/pkg/cmd/validate/validate_test.go
+++ b/pkg/cmd/validate/validate_test.go
@@ -36,6 +36,12 @@ func TestValidate(t *testing.T) {
 			want:      "",
 		},
 		{
+			name:      "single filepath - tekton.dev/v1 task",
+			args:      []string{"./testdata/task/v1-hello/0.1"},
+			wantError: false,
+			want:      "",
+		},
+		{
 			name:      "single filepath - with directory versioning flag",
 			args:      []string{"./testdata/task/maven/0.1", "--versioning", "directory"},
 			wantError: false,

--- a/pkg/linter/script.go
+++ b/pkg/linter/script.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/tektoncd/catlin/pkg/parser"
 	"github.com/tektoncd/catlin/pkg/validator"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
 type taskLinter struct {
@@ -87,8 +87,7 @@ func NewScriptLinter(r *parser.Resource) *taskLinter {
 	return &taskLinter{res: r, configs: NewConfig()}
 }
 
-// nolint: staticcheck
-func (t *taskLinter) validateScript(taskName string, s v1beta1.Step, configs []config) validator.Result {
+func (t *taskLinter) validateScript(taskName string, s v1.Step, configs []config) validator.Result {
 	result := validator.Result{}
 
 	// use /bin/sh by default if no shbang
@@ -151,8 +150,7 @@ func (t *taskLinter) validateScript(taskName string, s v1beta1.Step, configs []c
 	return result
 }
 
-// nolint: staticcheck
-func (t *taskLinter) collectOverSteps(steps []v1beta1.Step, name string, result *validator.Result) {
+func (t *taskLinter) collectOverSteps(steps []v1.Step, name string, result *validator.Result) {
 	for _, step := range steps {
 		if step.Script != "" {
 			result.Append(t.validateScript(name, step, t.configs))
@@ -160,7 +158,6 @@ func (t *taskLinter) collectOverSteps(steps []v1beta1.Step, name string, result 
 	}
 }
 
-// nolint: staticcheck
 func (t *taskLinter) Validate() validator.Result {
 	result := validator.Result{}
 	res, err := t.res.ToType()
@@ -171,7 +168,7 @@ func (t *taskLinter) Validate() validator.Result {
 
 	switch strings.ToLower(t.res.Kind) {
 	case "task":
-		task := res.(*v1beta1.Task)
+		task := res.(*v1.Task)
 		t.collectOverSteps(task.Spec.Steps, task.ObjectMeta.Name, &result)
 	}
 	return result

--- a/pkg/linter/script_test.go
+++ b/pkg/linter/script_test.go
@@ -82,6 +82,36 @@ var configSh = []config{
 	},
 }
 
+const v1TaskScriptValidatorGood = `
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: hello-moto-v1
+spec:
+  steps:
+  - name: s1
+    image: image1
+    script: |
+      #!/bin/sh
+      echo "hello moto"
+`
+
+// TestTaskLint_Script_v1 ensures the script linter works on tekton.dev/v1 Tasks.
+func TestTaskLint_Script_v1(t *testing.T) {
+	r := strings.NewReader(v1TaskScriptValidatorGood)
+	parser := parser.ForReader(r)
+
+	res, err := parser.Parse()
+	assert.NilError(t, err)
+
+	tl := &taskLinter{
+		res:     res,
+		configs: configSh,
+	}
+	result := tl.Validate()
+	assert.Equal(t, 0, result.Errors)
+}
+
 func TestTaskLint_Script_good(t *testing.T) {
 	r := strings.NewReader(taskScriptValidatorGood)
 	parser := parser.ForReader(r)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -29,12 +29,13 @@ import (
 	"knative.dev/pkg/apis"
 
 	"github.com/tektoncd/catlin/pkg/consts"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 func registerSchema() {
-	beta1 := runtime.NewSchemeBuilder(v1beta1.AddToScheme)
-	_ = beta1.AddToScheme(scheme.Scheme)
+	sb := runtime.NewSchemeBuilder(v1beta1.AddToScheme, v1.AddToScheme)
+	_ = sb.AddToScheme(scheme.Scheme)
 }
 
 type Resource struct {
@@ -150,13 +151,12 @@ type tektonResource interface {
 	apis.Defaultable
 }
 
-// nolint: staticcheck
 func typeForKind(kind string) (tektonResource, error) {
 	switch kind {
 	case "Task":
-		return &v1beta1.Task{}, nil
+		return &v1.Task{}, nil
 	case "Pipeline":
-		return &v1beta1.Pipeline{}, nil
+		return &v1.Pipeline{}, nil
 	}
 
 	return nil, fmt.Errorf("unknown kind %s", kind)
@@ -164,5 +164,6 @@ func typeForKind(kind string) (tektonResource, error) {
 
 func isTektonKind(gvk *schema.GroupVersionKind) bool {
 	id := gvk.GroupVersion().Identifier()
-	return id == v1beta1.SchemeGroupVersion.Identifier()
+	return id == v1.SchemeGroupVersion.Identifier() ||
+		id == v1beta1.SchemeGroupVersion.Identifier()
 }

--- a/pkg/validator/task_validator.go
+++ b/pkg/validator/task_validator.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	"github.com/tektoncd/catlin/pkg/parser"
 )
@@ -40,7 +40,6 @@ func NewTaskValidator(r *parser.Resource) *taskValidator {
 	return &taskValidator{res: r}
 }
 
-// nolint: staticcheck
 func (t *taskValidator) Validate() Result {
 	result := Result{}
 
@@ -50,14 +49,14 @@ func (t *taskValidator) Validate() Result {
 		return result
 	}
 
-	task := res.(*v1beta1.Task)
+	task := res.(*v1.Task)
 	for _, step := range task.Spec.Steps {
 		result.Append(t.validateStep(step))
 	}
 	return result
 }
 
-func (t *taskValidator) validateStep(s v1beta1.Step) Result {
+func (t *taskValidator) validateStep(s v1.Step) Result {
 	result := Result{}
 	step := s.Name
 	img := s.Image

--- a/pkg/validator/task_validator_test.go
+++ b/pkg/validator/task_validator_test.go
@@ -200,6 +200,81 @@ spec:
       print("""$(params.secret)""")
 `
 
+const v1TaskValidImageRef = `
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: v1-valid-image-refs
+  labels:
+    app.kubernetes.io/version: a,b,c
+  annotations:
+    tekton.dev/tags: a,b,c
+    tekton.dev/pipelines.minVersion: "0.12"
+    tekton.dev/displayName: My Example Task
+spec:
+  description: |-
+    A summary of the resource
+
+    A para about this valid task
+  steps:
+  - name: s1
+    image: docker.io/foo:bar
+  - name: s2
+    image: abc.io/fedora:1.0@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
+`
+
+const v1TaskInvalidImageRef = `
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: v1-invalid-image-refs
+  labels:
+    app.kubernetes.io/version: a,b,c
+  annotations:
+    tekton.dev/tags: a,b,c
+    tekton.dev/pipelines.minVersion: "0.12"
+    tekton.dev/displayName: My Example Task
+spec:
+  description: |-
+    A summary of the resource
+
+    A para about this valid task
+  steps:
+  - name: s1
+    image: ubuntu
+  - name: s2
+    image: api:latest
+`
+
+// TestTaskValidator_V1_ValidImageRef ensures tekton.dev/v1 Tasks are parsed
+// and validated just like v1beta1 ones.
+func TestTaskValidator_V1_ValidImageRef(t *testing.T) {
+	r := strings.NewReader(v1TaskValidImageRef)
+	parser := parser.ForReader(r)
+
+	res, err := parser.Parse()
+	assert.NilError(t, err)
+
+	v := ForKind(res)
+	result := v.Validate()
+	assert.Equal(t, 0, result.Errors)
+	assert.Equal(t, 0, len(result.Lints))
+}
+
+// TestTaskValidator_V1_InvalidImageRef ensures validation rules fire for v1.
+func TestTaskValidator_V1_InvalidImageRef(t *testing.T) {
+	r := strings.NewReader(v1TaskInvalidImageRef)
+	parser := parser.ForReader(r)
+
+	res, err := parser.Parse()
+	assert.NilError(t, err)
+
+	v := ForKind(res)
+	result := v.Validate()
+	// s1 "ubuntu": must be tagged (1 error); s2 "api:latest": latest (1 error)
+	assert.Equal(t, 2, result.Errors)
+}
+
 func TestTaskValidator_ValidImageRef(t *testing.T) {
 	r := strings.NewReader(taskWithValidImageRef)
 	parser := parser.ForReader(r)


### PR DESCRIPTION
# Changes

Adds support for validating and linting `tekton.dev/v1` resources, while keeping full backward compatibility with `tekton.dev/v1beta1`.

Fixes #10

catlin was hard-wired to `v1beta1`. This PR:

- **`pkg/parser`**: registers both the `v1` and `v1beta1` schemes, accepts both API group versions, and normalizes parsed resources to `v1` types. Since the fields catlin inspects (`Step.Image/Env/EnvFrom/Script`, `Task.Spec.Steps`) are identical across versions, `v1beta1` resources are decoded straight into `v1` types.
- **`pkg/validator`**: task validator now operates on `v1.Task` / `v1.Step`.
- **`pkg/linter`**: script linter now operates on `v1.Task` / `v1.Step`.

`ClusterTask` was already removed upstream and from catlin, so no work was needed there. The dependency is already on `tektoncd/pipeline v1.4.0`, which ships the `v1` API, so no further dependency bumps were required.

Adds `v1` fixtures and tests for the parser, validator, linter and the `validate` command; existing `v1beta1` tests are retained to prove backward compatibility.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add support for validating and linting `tekton.dev/v1` Task and Pipeline resources.
```