### PR TITLE
ci(.github/workflows): enable Codecov coverage reporting

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,19 @@
+coverage:
+  # Commit statuses https://docs.codecov.io/docs/commit-status are used
+  # to block PR based on coverage threshold.
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      # Disable the coverage threshold of the patch, so that PRs are
+      # only failing because of overall project coverage threshold.
+      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
+      default: false
+
+ignore:
+  - "hack/**"
+  - "test/**"
+  - "images/**"
+  - "vendor/**"

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -26,40 +26,78 @@ jobs:
     name: Go coverage
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
+      actions: read
       pull-requests: write
 
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           path: ${{ github.workspace }}/src/github.com/tektoncd/catlin
 
       - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/catlin/go.mod"
 
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/catlin
         run: |
-          go test -cover -coverprofile=coverage.txt ./... || true
+          go test -coverprofile=coverage.out -covermode=atomic ./... || true
           echo "Generated coverage profile"
 
       - name: Archive coverage results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage
-          path: ${{ github.workspace }}/src/github.com/tektoncd/catlin/coverage.txt
+          path: ${{ github.workspace }}/src/github.com/tektoncd/catlin/coverage.out
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
+        uses: fgrosse/go-coverage-report@cbeb2ab2e32591d690337146ba02a911cc566f3f # v1.3.0
         continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
         with:
           coverage-artifact-name: "code-coverage"
-          coverage-file-name: "coverage.txt"
+          coverage-file-name: "coverage.out"
+
+  codecov-upload:
+    name: Upload coverage to Codecov
+    if: github.event_name != 'pull_request'
+    needs: go-coverage
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: code-coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
+        continue-on-error: true
+        with:
+          files: coverage.out
+          flags: unit-tests
+          use_oidc: true
+          fail_ci_if_error: false


### PR DESCRIPTION
Add .codecov.yaml with coverage thresholds and an ignore list for non-source directories. Upload coverage to Codecov via OIDC alongside the existing artifact upload and PR-comment step.
Split the Codecov upload into a separate job that only runs on push/schedule/workflow_dispatch events. This keeps id-token: write out of the PR job, preventing untrusted fork PRs from minting OIDC tokens during test execution.

Assisted-by: Claude Sonnet 5 (via Claude Code)